### PR TITLE
Add state to processed ops and trim the table

### DIFF
--- a/stacks-coordinator/src/bitcoin_wallet.rs
+++ b/stacks-coordinator/src/bitcoin_wallet.rs
@@ -266,7 +266,8 @@ mod tests {
         assert_eq!(btc_tx.input.len(), 7);
         assert_eq!(btc_tx.output.len(), 3); // We have change!
         assert_eq!(btc_tx.output[0].value, 0);
-        assert_eq!(btc_tx.output[1].value, 10000);
+        assert_eq!(btc_tx.output[1].value, amount);
+        assert_eq!(btc_tx.output[2].value, 10000);
     }
 
     #[test]

--- a/stacks-coordinator/src/peg_queue/mod.rs
+++ b/stacks-coordinator/src/peg_queue/mod.rs
@@ -5,7 +5,7 @@ use crate::stacks_node;
 use crate::stacks_node::Error as StacksNodeError;
 mod sqlite_peg_queue;
 
-pub use sqlite_peg_queue::{Error as SqlitePegQueueError, SqlitePegQueue};
+pub use sqlite_peg_queue::{Error as SqlitePegQueueError, SqlitePegQueue, Status};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -16,11 +16,14 @@ pub enum Error {
 }
 
 pub trait PegQueue {
-    fn sbtc_op(&self) -> Result<Option<SbtcOp>, Error>;
+    fn sbtc_op(&self) -> Result<Option<(SbtcOp, Status)>, Error>;
     fn poll<N: stacks_node::StacksNode>(&self, stacks_node: &N) -> Result<(), Error>;
-
-    fn acknowledge(&self, txid: &Txid, burn_header_hash: &BurnchainHeaderHash)
-        -> Result<(), Error>;
+    fn update_status(
+        &self,
+        txid: &Txid,
+        burn_header_hash: &BurnchainHeaderHash,
+        status: Status,
+    ) -> Result<(), Error>;
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/stacks-coordinator/src/peg_wallet.rs
+++ b/stacks-coordinator/src/peg_wallet.rs
@@ -21,7 +21,7 @@ pub enum Error {
 }
 
 pub trait StacksWallet {
-    /// Builds a verified signed transaction for a given peg-in operation
+    /// Builds a verified signed transaction for a given operation
     fn build_transaction<T: BuildStacksTransaction>(
         &self,
         op: &T,


### PR DESCRIPTION
I didn't have internet for a majority of the day, so just spent some time looking over the code and seeing what sort of improved state I could easily add.

This is not entirely necessary, but now it will poll for withdrawals and deposits and save its last processed state. It should help with continually broadcasting sBTC transactions for a half processed transaction if the coordinator crashes. It will be smart enough to pick up where it left off to some extent now. Still not perfect by any means but I think its a worthwhile change. Feel free to suggest improvements on it.

I trim the table of completed transactions, however, I could leave them and add logic to not overwrite completed transactions with new ones if we set the blockheight back in time, but I feel like we would expect these to be forcibly reprocessed if we are setting the blockheight back...so I think trimming the table makes more sense. (The case of the coordinator processing most but not all the transactions at some block height seems unlikely and would be the only scenario I can think of where we would want to go back in time and process some but not all the transactions at a given block height...We currently poll all peg ins and all peg outs before attempting processing so they would all be already stored in the database with status::NEW for a given block height)