### PR TITLE
[sbtc-mini] feat: Basic Mermaid Call Graph Script

### DIFF
--- a/sbtc-mini/.mermaid/generated-mermaid.mmd
+++ b/sbtc-mini/.mermaid/generated-mermaid.mmd
@@ -1,0 +1,24 @@
+graph TD
+  sbtc-registry -->|is-protocol-caller| sbtc-controller
+  sbtc-token -->|is-protocol-caller| sbtc-controller
+  sbtc-stacking-pool -->|get-pox-info\ncurrent-pox-reward-cycle\nburn-height-to-reward-cycle\nget-allowance-contract-callers\ndelegate-stx\n+ 3 more functions| pox-3
+  sbtc-stacking-pool -->|is-protocol-caller| sbtc-controller
+  sbtc-stacking-pool -->|current-peg-state\nget-pending-wallet-peg-outs\nset-peg-state| sbtc-registry
+  sbtc-stacking-pool -->|parse-tx\nwas-segwit-tx-mined-compact| clarity-bitcoin
+  sbtc-stacking-pool -->|hashbytes-to-scriptpubkey| sbtc-btc-tx-helper
+  sbtc-testnet-debug-controller -->|upgrade| sbtc-controller
+  sbtc-testnet-debug-controller -->|simulate-mine-solo-burnchain-block| sbtc-testnet-debug-controller
+  sbtc-testnet-debug-controller -->|was-tx-mined-compact| clarity-bitcoin
+  sbtc-peg-out-processor -->|was-segwit-tx-mined-compact| clarity-bitcoin
+  sbtc-peg-out-processor -->|assert-new-burn-wtxid-and-height\ninsert-peg-out-request\nget-and-settle-pending-peg-out-request| sbtc-registry
+  sbtc-peg-out-processor -->|protocol-lock\nprotocol-burn-locked\nprotocol-unlock| sbtc-token
+  sbtc-btc-tx-helper -->|parse-wtx\nget-txid| clarity-bitcoin
+  sbtc-btc-tx-helper -->|current-pox-reward-cycle| pox-3
+  sbtc-btc-tx-helper -->|get-cycle-peg-wallet| sbtc-registry
+  sbtc-peg-in-processor -->|was-segwit-tx-mined\nget-peg-wallet-hashbytes-scriptpubkey\nfind-protocol-unlock-witness| sbtc-btc-tx-helper
+  sbtc-peg-in-processor -->|assert-new-burn-wtxid-and-height| sbtc-registry
+  sbtc-peg-in-processor -->|protocol-mint| sbtc-token
+  sbtc-peg-transfer -->|get-current-cycle-pool\nget-specific-cycle-pool\nget-current-window\nbalance-was-transferred| sbtc-stacking-pool
+  sbtc-peg-transfer -->|get-peg-balance| sbtc-registry
+  sbtc-peg-transfer -->|parse-tx\nwas-segwit-tx-mined-compact| clarity-bitcoin
+  sbtc-peg-transfer -->|hashbytes-to-scriptpubkey| sbtc-btc-tx-helper

--- a/sbtc-mini/README.md
+++ b/sbtc-mini/README.md
@@ -151,3 +151,18 @@ Examples:
 ;; @mine-blocks-before 5
 (define-public (test-six) (ok true))
 ```
+
+
+## Mermaid Call Graph
+
+In order to best answer "what is sBTC-mini?", we've included a tiny helper script for anyone to generate & update the protocol call graph at any point in time.
+
+### Generating Graph
+
+From your terminal, CD into sbtc-mini, run "bash ./scripts/mermaid.sh", then check the ".mermaid" directory for the updated "generated-mermaid.mmd" file.
+
+### Viewing Graph
+
+To view the generated graph, for now, head to Mermaid's live editor & copy/paste the code or upload the generated file.
+
+Each box represents a contract & each line represents one or more functions from one contract to another.

--- a/sbtc-mini/ext/generate-mermaid.ts
+++ b/sbtc-mini/ext/generate-mermaid.ts
@@ -1,0 +1,78 @@
+import { Clarinet, Contract, Account } from 'https://deno.land/x/clarinet@v1.7.0/index.ts';
+
+const targetFolder = '.mermaid';
+
+function getContractName(contractId: string) {
+    return contractId.split('.')[1];
+}
+
+Clarinet.run({
+    async fn(accounts: Map<string, Account>, contracts: Map<string, Contract>) {
+
+        const code: string[] = [];
+        code.push("graph TD");
+
+        // A map of maps to hold the function calls between contracts
+        const contractCallsMap: Map<string, Map<string, Set<string>>> = new Map();
+
+        for (const [contractId, contract] of contracts) {
+            const contractName = getContractName(contractId);
+            
+            // Skip contracts with '_test' in the name
+            if (contractName.includes('_test')) continue;
+
+            const contractCalls = extractContractCalls(contract.source);
+            for (const call of contractCalls) {
+                // If the source contract is not in the map, add it
+                if (!contractCallsMap.has(contractName)) {
+                    contractCallsMap.set(contractName, new Map());
+                }
+
+                // If the target contract is not in the map, add it
+                if (!contractCallsMap.get(contractName)!.has(call.contractName)) {
+                    contractCallsMap.get(contractName)!.set(call.contractName, new Set());
+                }
+
+                // Add the function call to the map
+                contractCallsMap.get(contractName)!.get(call.contractName)!.add(call.functionName);
+            }
+        }
+
+        // Iterate over the contract calls map to generate the Mermaid code
+        for (const [sourceContract, targetMap] of contractCallsMap) {
+            for (const [targetContract, functionNames] of targetMap) {
+                let functionNamesArray = Array.from(functionNames);
+                let functionNamesToDisplay = functionNamesArray.slice(0, 5);
+                let remainingFunctions = functionNamesArray.length - 5;
+
+                if (remainingFunctions > 0) {
+                    functionNamesToDisplay.push(`+ ${remainingFunctions} more functions`);
+                }
+
+                // Display the function names
+                code.push(`  ${sourceContract} -->|${functionNamesToDisplay.join("\\n")}| ${targetContract}`);
+            }
+        }
+
+        Deno.writeTextFile(`${targetFolder}/generated-mermaid.mmd`, code.join("\n"));
+    }
+});
+
+type ContractCall = {
+    contractName: string;
+    functionName: string;
+};
+
+function extractContractCalls(contractSource: string): ContractCall[] {
+    const contractCalls: ContractCall[] = [];
+    const regex = /\(contract-call\? \.(.+?) (.+?)(( .+?)*)\)/g;
+    let match;
+
+    while ((match = regex.exec(contractSource)) !== null) {
+        const contractName = match[1];
+        const functionName = match[2];
+        contractCalls.push({ contractName, functionName });
+    }
+
+    return contractCalls;
+}

--- a/sbtc-mini/scripts/mermaid.sh
+++ b/sbtc-mini/scripts/mermaid.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir -p .mermaid
+clarinet run --allow-write --allow-read ext/generate-mermaid.ts


### PR DESCRIPTION
Tiny feature that allows the sbtc-mini working group to generate a call graph (like the one attached below or seen [here](https://mermaid.live/view#pako:eNqlVbty4zAM_BWN2gurdC6uyh_clWooEpY4pkAeCY6sifLvB8qyIr-UeNJZIB6LxQJ-L5XTUO7KJkjfFn_fKiyKWJMSARoTKQyFEL9HE4UPjpxyVihpLYTx5KUcUnDZsASSOwA-HRVJqoPBRnjn7BTdAPHHURjcu6pClUIAPJkC9DJooQZlgZ_qFFC0YJqWuPr1a87DxV0vUcGptFQ0A4rsoMFCIwkYw5E_fxWvRecCFPuEiozDOBa56OsG1p91urQGTX6lM2oPqLNjnzOenl2iDDnCynu8HNhGIS9DBDF12csoIjS9YcqOojMIzJjrPFMzFsrKYGgQtSHlDG5kbGVs64EgZuKjCsaTT_UBhhnUJIgjD8f6tUQgEnILGurUrDiaUibPWtSwIbCt6Gi6ZPMwc0siOutElodqpUFRW6cO43aW75XJ9H2ft3lyWSMKYnSfOZ4ewf1UMkYIJBD6qVvR09FoIVHPa8EDNzi5nOMD_Evc4Hk_2JM1RRYW0V05PhLZfTzLMmTCucbyPaHLRtBrc8L1ZPIBWQpcKGil4n6ScQafe31M2G38o0tyvea3kbna5Dq1fVrLLWJYcl-OfNn1Zc8_d2q9UOy3NzymK84E50IusLlvd7F8pZmnGltQcU90d445jC8vxv2azHkUM6l8VWY6ogdl9kbdvpxDeibD9fn6Sztd9mkl5wIB9HjnZG2DycY52VbvF3E_vag3CZ86qOVL2UHopNH8D_6ek1YltdBBVe74p5bhUJUVfrCfTOT-DKjKHYUEL2Xymq_km5F8bLuT8eM_kfICEA)) in order to provide more visibility to stakeholders. 

Instructions in the sbtc-mini README & should be ran after any merge that adds/edits/remove contract-calls? in any one of the protocol contracts.

User Stories
- [ ] Running "bash ./scripts/mermaid.sh" from the sbtc-mini directory updates the "generated-mermaid.mmd" file in the .mermaid directory
- [ ] When a (contract-call? ...) is added the function name appears along the edge between the calling & receiving contract