### PR TITLE
Asyncify the repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ hashbrown = { version = "0.14", features = ["serde"] }
 bincode = "1.3.3"
 itertools = "^0.11.0"
 sha2 = "0.10"
-ureq = { version = "2.6", features = ["json"] }
 url = "2.3.1"
 rand = "0.8.5"
 backoff = "0.4"
@@ -47,3 +46,6 @@ aes-gcm = "0.10"
 sha256 = "=1.4.0"
 secp256k1 = { version = "0.27.0", features = ["global-context", "recovery", "serde", "bitcoin-hashes"] }
 regex = "~1.8.4"
+tokio = "1.32.0"
+ureq = { version = "2.7.1", features = ["json"]}
+async-trait = "0.1.73"

--- a/frost-coordinator/Cargo.toml
+++ b/frost-coordinator/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 frost-signer = { path = "../frost-signer" }
 serde = { version = "1.0", features = ["serde_derive"] }
+tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 rand_core = { workspace = true }

--- a/frost-coordinator/src/main.rs
+++ b/frost-coordinator/src/main.rs
@@ -15,14 +15,14 @@ pub struct Cli {
     pub command: Command,
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     logging::initiate_tracing_subscriber();
 
     let cli = Cli::parse();
     match create_coordinator_from_path(cli.config) {
         Ok(mut coordinator) => {
-            let result = coordinator.run(&cli.command);
-            if let Err(e) = result {
+            if let Err(e) = coordinator.run(&cli.command).await {
                 warn!("Failed to execute command: {}", e);
             }
         }

--- a/frost-signer/Cargo.toml
+++ b/frost-signer/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]   # The crate types to generate.
 
 [dependencies]
 aes-gcm = { workspace = true }
-backoff = { workspace = true }
+backoff = { workspace = true, features = ["tokio"] }
 bincode = { workspace = true }
 clap = { workspace = true }
 p256k1 = { workspace = true }
@@ -26,5 +26,7 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-ureq = { workspace = true }
+reqwest = { workspace = true }
 rand = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }

--- a/frost-signer/src/main.rs
+++ b/frost-signer/src/main.rs
@@ -5,7 +5,8 @@ use frost_signer::config::{Cli, Config};
 use frost_signer::logging;
 use frost_signer::signer::Signer;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     logging::initiate_tracing_subscriber();
 
     let cli = Cli::parse();
@@ -20,7 +21,7 @@ fn main() {
             ); // sign-on message
 
             //Start listening for p2p messages
-            if let Err(e) = signer.start_p2p_sync() {
+            if let Err(e) = signer.start_p2p_async().await {
                 warn!("An error occurred in the P2P Network: {}", e);
             }
         }

--- a/frost-signer/tests/net.rs
+++ b/frost-signer/tests/net.rs
@@ -1,8 +1,8 @@
 use frost_signer::net::{HttpNet, HttpNetListen, Message, NetListen};
 use frost_signer::signing_round::{DkgBegin, MessageTypes};
 
-#[test]
-fn receive_msg() {
+#[tokio::test]
+async fn receive_msg() {
     let m1 = Message {
         msg: MessageTypes::DkgBegin(DkgBegin { dkg_id: 0 }),
         sig: vec![0u8; 64],
@@ -12,8 +12,8 @@ fn receive_msg() {
 
     let in_queue = vec![m1];
     let net = HttpNet::new(stacks_node_url);
-    let mut net_listen = HttpNetListen::new(net, in_queue);
-    match net_listen.next_message() {
+    let net_listen = HttpNetListen::new(net, in_queue);
+    match net_listen.next_message().await {
         Some(_msg) => {
             assert!(true)
         }

--- a/frost-test/Cargo.toml
+++ b/frost-test/Cargo.toml
@@ -14,7 +14,7 @@ frost-signer = { path = "../frost-signer" }
 rand_core = { workspace = true }
 hashbrown = { workspace = true }
 wsts = { workspace = true }
-ureq = { workspace = true }
+reqwest = { workspace = true }
 bitcoin = { version = "0.29.2", features = ["rand"] }
 hex.workspace = true
 ctrlc = "3.2.5"

--- a/stacks-coordinator/Cargo.toml
+++ b/stacks-coordinator/Cargo.toml
@@ -14,7 +14,8 @@ blockstack-core = { workspace = true }
 clap = { workspace = true }
 frost-coordinator = { path = "../frost-coordinator" }
 frost-signer = { path = "../frost-signer" }
-rusqlite = { workspace = true }
+rusqlite.workspace = true
+tokio-rusqlite = "0.4.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 stacks-signer = { path = "../stacks-signer" }
@@ -24,12 +25,13 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 wsts = { workspace = true }
 bitcoin.workspace = true
-reqwest = { version = "0.11.14", features = ["blocking", "json"] }
+reqwest = { version = "0.11.14", features = ["json"] }
 backoff = { workspace = true }
-ureq.workspace = true
 url = { workspace = true }
+async-trait = { workspace = true }
 bdk.workspace = true
 hex.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/stacks-coordinator/Cargo.toml
+++ b/stacks-coordinator/Cargo.toml
@@ -14,8 +14,7 @@ blockstack-core = { workspace = true }
 clap = { workspace = true }
 frost-coordinator = { path = "../frost-coordinator" }
 frost-signer = { path = "../frost-signer" }
-rusqlite.workspace = true
-tokio-rusqlite = "0.4.0"
+sqlx = { version = "0.5", features = ["sqlite", "runtime-tokio-native-tls", "offline"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 stacks-signer = { path = "../stacks-signer" }

--- a/stacks-coordinator/src/coordinator.rs
+++ b/stacks-coordinator/src/coordinator.rs
@@ -20,7 +20,6 @@ use std::{
     fs::File,
     path::{Path, PathBuf},
     sync::mpsc::RecvError,
-    thread::sleep,
     time::Duration,
 };
 use tracing::{debug, info, warn};
@@ -37,6 +36,7 @@ use crate::{
     },
     stacks_wallet::BuildStacksTransaction,
 };
+use async_trait::async_trait;
 
 // Traits in scope
 use crate::bitcoin_node::{
@@ -98,11 +98,12 @@ pub enum Error {
     PointError(String),
 }
 
-pub trait Coordinator: Sized {
-    type PegQueue: PegQueue;
+#[async_trait]
+pub trait Coordinator: Sized + Send {
+    type PegQueue: PegQueue + Send + Sync;
     type FeeWallet: PegWallet;
     type StacksNode: StacksNode;
-    type BitcoinNode: BitcoinNode;
+    type BitcoinNode: BitcoinNode + Send + Sync;
 
     // Required methods
     fn peg_queue(&self) -> &Self::PegQueue;
@@ -115,26 +116,27 @@ pub trait Coordinator: Sized {
     fn bitcoin_node(&self) -> &Self::BitcoinNode;
 
     // Provided methods
-    fn run(mut self, polling_interval: u64) -> Result<()> {
+    async fn run(mut self, polling_interval: u64) -> Result<()> {
         loop {
             info!("Polling for withdrawal and deposit requests to process...");
             self.peg_queue().poll(self.stacks_node())?;
-            self.process_queue()?;
+            self.process_queue().await?;
 
-            sleep(Duration::from_secs(polling_interval));
+            tokio::time::sleep(Duration::from_secs(polling_interval)).await;
         }
     }
 
-    fn process_queue(&mut self) -> Result<()> {
+    async fn process_queue(&mut self) -> Result<()> {
+        let peg_queue = self.peg_queue();
         loop {
-            match self.peg_queue().sbtc_op()? {
+            match peg_queue.sbtc_op()? {
                 Some(SbtcOp::PegIn(op)) => {
                     debug!("Processing peg in request: {:?}", op);
                     self.peg_in(op)?;
                 }
                 Some(SbtcOp::PegOutRequest(op)) => {
                     debug!("Processing peg out request: {:?}", op);
-                    self.peg_out(op)?;
+                    self.peg_out(op).await?;
                 }
                 None => return Ok(()),
             }
@@ -143,24 +145,26 @@ pub trait Coordinator: Sized {
 }
 
 // Private helper functions
+#[async_trait]
 trait CoordinatorHelpers: Coordinator {
     fn peg_in(&mut self, op: stacks_node::PegInOp) -> Result<()> {
         // Build a transaction from the peg in op and broadcast it to the node with reattempts
         self.try_broadcast_transaction(&op)
     }
 
-    fn peg_out(&mut self, op: stacks_node::PegOutRequestOp) -> Result<()> {
+    async fn peg_out(&mut self, op: stacks_node::PegOutRequestOp) -> Result<()> {
         // First build both the sBTC and BTC transactions before attempting to broadcast either of them
         // This ensures that if either of the transactions fail to build, neither of them will be broadcast
 
         // Build and sign a fulfilled bitcoin transaction
-        let fulfill_tx = self.fulfill_peg_out(&op)?;
+        let fulfill_tx = self.fulfill_peg_out(&op).await?;
 
         // Build a transaction from the peg out request op and broadcast it to the node with reattempts
         self.try_broadcast_transaction(&op)?;
 
         // Broadcast the BTC transaction to the Bitcoin node
-        self.bitcoin_node().broadcast_transaction(&fulfill_tx)?;
+        let btc_node = self.bitcoin_node();
+        btc_node.broadcast_transaction(&fulfill_tx).await?;
         info!(
             "Broadcasted fulfilled BTC transaction: {}",
             fulfill_tx.txid()
@@ -168,11 +172,12 @@ trait CoordinatorHelpers: Coordinator {
         Ok(())
     }
 
-    fn fulfill_peg_out(&mut self, op: &stacks_node::PegOutRequestOp) -> Result<BitcoinTransaction> {
+    async fn fulfill_peg_out(&mut self, op: &stacks_node::PegOutRequestOp) -> Result<BitcoinTransaction> {
         // Retreive the utxos
-        let utxos = self
-            .bitcoin_node()
-            .list_unspent(self.fee_wallet().bitcoin().address())?;
+        let address = self.fee_wallet().bitcoin().address();
+        let btc_node = self.bitcoin_node();
+        let utxos = btc_node
+            .list_unspent(address).await?;
 
         // Build unsigned fulfilled peg out transaction
         let (mut tx, prevouts) = self.fee_wallet().bitcoin().fulfill_peg_out(op, utxos)?;
@@ -189,7 +194,7 @@ trait CoordinatorHelpers: Coordinator {
                 .map_err(Error::SigningError)?;
             let (_frost_sig, schnorr_proof) = self
                 .frost_coordinator_mut()
-                .sign_message(&taproot_sighash.as_hash())?;
+                .sign_message(&taproot_sighash.as_hash()).await?;
 
             debug!(
                 "Fulfill Tx {:?} SchnorrProof ({},{})",
@@ -269,14 +274,14 @@ pub struct StacksCoordinator {
 }
 
 impl StacksCoordinator {
-    pub fn run_dkg_round(&mut self) -> Result<XOnlyPublicKey> {
-        let p = self.frost_coordinator.run_distributed_key_generation()?;
+    pub async fn run_dkg_round(&mut self) -> Result<XOnlyPublicKey> {
+        let p = self.frost_coordinator.run_distributed_key_generation().await?;
         XOnlyPublicKey::from_slice(&p.x().to_bytes())
             .map_err(|e| Error::InvalidPublicKey(e.to_string()))
     }
 
-    pub fn sign_message(&mut self, message: &str) -> Result<(Signature, SchnorrProof)> {
-        Ok(self.frost_coordinator.sign_message(message.as_bytes())?)
+    pub async fn sign_message(&mut self, message: &str) -> Result<(Signature, SchnorrProof)> {
+        Ok(self.frost_coordinator.sign_message(message.as_bytes()).await?)
     }
 }
 
@@ -409,7 +414,7 @@ fn write_dkg_public_shares(
     Ok(())
 }
 
-fn load_dkg_data(
+async fn load_dkg_data(
     data_directory: Option<&str>,
     frost_coordinator: &mut FrostCoordinator,
     stacks_node: &mut NodeClient,
@@ -429,7 +434,7 @@ fn load_dkg_data(
         Ok(xonly_pubkey)
     } else {
         // If we don't get one stored in the contract...run the DKG round and get the resulting public key and use that
-        let point = frost_coordinator.run_distributed_key_generation()?;
+        let point = frost_coordinator.run_distributed_key_generation().await?;
 
         if let Some(data_directory) = data_directory {
             write_dkg_public_shares(data_directory, frost_coordinator.get_dkg_public_shares())?;
@@ -447,63 +452,60 @@ fn load_dkg_data(
     }
 }
 
-impl TryFrom<&Config> for StacksCoordinator {
-    type Error = Error;
-    fn try_from(config: &Config) -> Result<Self> {
-        info!("Initializing stacks coordinator...");
-        let mut local_stacks_node = NodeClient::new(
-            config.stacks_node_rpc_url.clone(),
-            config.contract_name.clone(),
-            config.contract_address,
-        );
+async fn config_to_stacks_coordinator(config: &Config) -> Result<StacksCoordinator> {
+    info!("Initializing stacks coordinator...");
+    let mut local_stacks_node = NodeClient::new(
+        config.stacks_node_rpc_url.clone(),
+        config.contract_name.clone(),
+        config.contract_address,
+    );
 
-        let stacks_wallet = StacksWallet::new(
-            config.contract_name.clone(),
-            config.contract_address,
-            config.stacks_private_key,
-            config.stacks_address,
-            config.stacks_version,
-            config.transaction_fee,
-        );
+    let stacks_wallet = StacksWallet::new(
+        config.contract_name.clone(),
+        config.contract_address,
+        config.stacks_private_key,
+        config.stacks_address,
+        config.stacks_version,
+        config.transaction_fee,
+    );
 
-        let mut frost_coordinator =
-            create_frost_coordinator(config, &mut local_stacks_node, &stacks_wallet)?;
+    let mut frost_coordinator =
+        create_frost_coordinator(config, &mut local_stacks_node, &stacks_wallet)?;
 
-        // Load the public key from either the frost_coordinator or the sBTC contract
-        let xonly_pubkey = load_dkg_data(
-            config.data_directory.as_deref(),
-            &mut frost_coordinator,
-            &mut local_stacks_node,
-            &stacks_wallet,
-            &config.stacks_address,
-        )?;
-        let bitcoin_wallet = BitcoinWallet::new(xonly_pubkey, config.bitcoin_network);
+    // Load the public key from either the frost_coordinator or the sBTC contract
+    let xonly_pubkey = load_dkg_data(
+        config.data_directory.as_deref(),
+        &mut frost_coordinator,
+        &mut local_stacks_node,
+        &stacks_wallet,
+        &config.stacks_address,
+    ).await?;
+    let bitcoin_wallet = BitcoinWallet::new(xonly_pubkey, config.bitcoin_network);
 
-        // Load the bitcoin wallet
-        let local_bitcoin_node = LocalhostBitcoinNode::new(config.bitcoin_node_rpc_url.clone());
-        local_bitcoin_node.load_wallet(bitcoin_wallet.address())?;
+    // Load the bitcoin wallet
+    let local_bitcoin_node = LocalhostBitcoinNode::new(config.bitcoin_node_rpc_url.clone());
+    local_bitcoin_node.load_wallet(bitcoin_wallet.address()).await?;
 
-        // If a user has not specified a start block height, begin from the current burn block height by default
-        let start_block_height = config.start_block_height;
-        let current_block_height = local_stacks_node.burn_block_height()?;
-        let local_peg_queue = if let Some(path) = &config.data_directory {
-            let db_path = PathBuf::from(path).join("peg_queue.sqlite");
-            SqlitePegQueue::new(db_path, start_block_height, current_block_height)
-        } else {
-            SqlitePegQueue::in_memory(start_block_height, current_block_height)
-        }?;
+    // If a user has not specified a start block height, begin from the current burn block height by default
+    let start_block_height = config.start_block_height;
+    let current_block_height = local_stacks_node.burn_block_height()?;
+    let local_peg_queue = if let Some(path) = &config.data_directory {
+        let db_path = PathBuf::from(path).join("peg_queue.sqlite");
+        SqlitePegQueue::new(db_path, start_block_height, current_block_height)
+    } else {
+        SqlitePegQueue::in_memory(start_block_height, current_block_height)
+    }?;
 
-        Ok(Self {
-            local_peg_queue,
-            local_stacks_node,
-            local_bitcoin_node,
-            frost_coordinator,
-            local_fee_wallet: WrapPegWallet {
-                bitcoin_wallet,
-                stacks_wallet,
-            },
-        })
-    }
+    Ok(StacksCoordinator {
+        local_peg_queue,
+        local_stacks_node,
+        local_bitcoin_node,
+        frost_coordinator,
+        local_fee_wallet: WrapPegWallet {
+            bitcoin_wallet,
+            stacks_wallet,
+        },
+    })
 }
 
 impl Coordinator for StacksCoordinator {

--- a/stacks-coordinator/src/main.rs
+++ b/stacks-coordinator/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use frost_signer::logging;
 use stacks_coordinator::cli::{Cli, Command};
 use stacks_coordinator::config::Config;
-use stacks_coordinator::coordinator::{Coordinator, StacksCoordinator};
+use stacks_coordinator::coordinator::{config_to_stacks_coordinator, Coordinator};
 use tracing::{error, info, warn};
 
 #[tokio::main]
@@ -20,26 +20,26 @@ async fn main() {
                 return;
             }
             config.start_block_height = cli.start_block_height;
-            match StacksCoordinator::try_from(&config) {
+            match config_to_stacks_coordinator(&config).await {
                 Ok(mut coordinator) => {
                     // Determine what action the caller wishes to perform
                     match cli.command {
                         Command::Run => {
                             info!("Running Coordinator");
                             //TODO: set up coordination with the stacks node
-                            if let Err(e) = coordinator.run(config.polling_interval) {
+                            if let Err(e) = coordinator.run(config.polling_interval).await {
                                 error!("An error occurred running the coordinator: {}", e);
                             }
                         }
                         Command::Dkg => {
                             info!("Running DKG Round");
-                            if let Err(e) = coordinator.run_dkg_round() {
+                            if let Err(e) = coordinator.run_dkg_round().await {
                                 error!("An error occurred during DKG round: {}", e);
                             }
                         }
                         Command::DkgSign => {
                             info!("Running DKG Round");
-                            if let Err(e) = coordinator.run_dkg_round() {
+                            if let Err(e) = coordinator.run_dkg_round().await {
                                 warn!("An error occurred during DKG round: {}", e);
                             };
                             info!("Running Signing Round");

--- a/stacks-coordinator/src/main.rs
+++ b/stacks-coordinator/src/main.rs
@@ -5,7 +5,8 @@ use stacks_coordinator::config::Config;
 use stacks_coordinator::coordinator::{Coordinator, StacksCoordinator};
 use tracing::{error, info, warn};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
 
     logging::initiate_tracing_subscriber();
@@ -43,7 +44,7 @@ fn main() {
                             };
                             info!("Running Signing Round");
                             let (signature, schnorr_proof) =
-                                match coordinator.sign_message("Hello, world!") {
+                                match coordinator.sign_message("Hello, world!").await {
                                     Ok((sig, proof)) => (sig, proof),
                                     Err(e) => {
                                         panic!("signing message failed: {e}");

--- a/stacks-coordinator/src/peg_queue/mod.rs
+++ b/stacks-coordinator/src/peg_queue/mod.rs
@@ -15,12 +15,16 @@ pub enum Error {
     StacksNodeError(#[from] StacksNodeError),
 }
 
+#[async_trait::async_trait]
 pub trait PegQueue {
-    fn sbtc_op(&self) -> Result<Option<SbtcOp>, Error>;
-    fn poll<N: stacks_node::StacksNode>(&self, stacks_node: &N) -> Result<(), Error>;
+    async fn sbtc_op(&self) -> Result<Option<SbtcOp>, Error>;
+    async fn poll<N: stacks_node::StacksNode>(&self, stacks_node: &N) -> Result<(), Error>;
 
-    fn acknowledge(&self, txid: &Txid, burn_header_hash: &BurnchainHeaderHash)
-        -> Result<(), Error>;
+    async fn acknowledge(
+        &self,
+        txid: &Txid,
+        burn_header_hash: &BurnchainHeaderHash,
+    ) -> Result<(), Error>;
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/stacks-coordinator/src/stacks_node/mod.rs
+++ b/stacks-coordinator/src/stacks_node/mod.rs
@@ -50,7 +50,7 @@ pub enum Error {
 }
 
 #[cfg_attr(test, mockall::automock)]
-pub trait StacksNode {
+pub trait StacksNode: Send + Sync {
     fn get_peg_in_ops(&self, block_height: u64) -> Result<Vec<PegInOp>, Error>;
     fn get_peg_out_request_ops(&self, block_height: u64) -> Result<Vec<PegOutRequestOp>, Error>;
     fn burn_block_height(&self) -> Result<u64, Error>;

--- a/stacks-signer-api/Cargo.toml
+++ b/stacks-signer-api/Cargo.toml
@@ -13,7 +13,7 @@ secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded = "0.7"
-rusqlite.workspace = true
+sqlx = { version = "0.5", features = ["sqlite", "runtime-tokio-native-tls", "offline"] }
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
 thiserror.workspace = true

--- a/stacks-signer-api/Cargo.toml
+++ b/stacks-signer-api/Cargo.toml
@@ -13,7 +13,7 @@ secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded = "0.7"
-sqlx = { version = "0.5", features = ["sqlite", "runtime-tokio-native-tls", "offline"] }
+rusqlite.workspace = true
 tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
 thiserror.workspace = true

--- a/stacks-signer-api/src/db/transaction.rs
+++ b/stacks-signer-api/src/db/transaction.rs
@@ -120,8 +120,7 @@ pub async fn get_transaction_by_id(txid: &str, pool: &SqlitePool) -> Result<Tran
     let transaction_debit_address =
         TransactionAddress::Bitcoin(row.transaction_debit_address.clone());
 
-    let transaction_credit_address =
-        TransactionAddress::Bitcoin(row.transaction_credit_address.clone());
+    let transaction_credit_address = TransactionAddress::Bitcoin(row.transaction_credit_address);
 
     Ok(Transaction {
         txid,

--- a/stacks-signer/Cargo.toml
+++ b/stacks-signer/Cargo.toml
@@ -15,6 +15,7 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 wsts = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/stacks-signer/src/main.rs
+++ b/stacks-signer/src/main.rs
@@ -6,7 +6,8 @@ use stacks_signer::signer::Signer;
 use tracing::info;
 use wsts::Point;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
 
     // Initialize logging
@@ -20,7 +21,7 @@ fn main() {
                 Ok(config) => {
                     let mut signer = Signer::new(config, id);
                     info!("{} signer id #{}", stacks_signer::version(), id); // sign-on message
-                    if let Err(e) = signer.start_p2p_sync() {
+                    if let Err(e) = signer.start_p2p_async().await {
                         panic!("An error occurred on the P2P Network: {}", e);
                     }
                 }

--- a/stacks-signer/src/signer.rs
+++ b/stacks-signer/src/signer.rs
@@ -14,7 +14,7 @@ impl Signer {
         }
     }
 
-    pub fn start_p2p_sync(&mut self) -> Result<(), SignerError> {
-        self.frost_signer.start_p2p_sync()
+    pub async fn start_p2p_async(&mut self) -> Result<(), SignerError> {
+        self.frost_signer.start_p2p_async().await
     }
 }


### PR DESCRIPTION
Using blocking code is an old pattern that is susceptible to the c10k problem, especially since we are in a networking context. We should default to async code to speed up performance.

* Use sqlx over rusqlite
* Use reqwest over ureq
* Use tokio::sync::mpsc::UnboundedSender/Receiver over std::sync::mpsc::Sender/Receiver